### PR TITLE
Fix Server error 500 on ajax call.

### DIFF
--- a/src/AtkWp.php
+++ b/src/AtkWp.php
@@ -291,7 +291,7 @@ class AtkWp
         }
 
         $this->ajaxMode = true;
-        if ($request = @$_REQUEST['atkwp']){
+        if ($request = @$_REQUEST['atkwp']) {
             $this->wpComponent = $this->componentCtrl->searchComponentByKey($request);
         }
 

--- a/src/AtkWp.php
+++ b/src/AtkWp.php
@@ -295,7 +295,6 @@ class AtkWp
             $this->wpComponent = $this->componentCtrl->searchComponentByKey($request);
         }
 
-
         $name = $this->pluginName;
 
         // check if this component has been output more than once

--- a/src/AtkWp.php
+++ b/src/AtkWp.php
@@ -291,7 +291,10 @@ class AtkWp
         }
 
         $this->ajaxMode = true;
-        $this->wpComponent = $this->componentCtrl->searchComponentByKey($_REQUEST['atkwp']);
+        if ($request = @$_REQUEST['atkwp']){
+            $this->wpComponent = $this->componentCtrl->searchComponentByKey($request);
+        }
+
 
         $name = $this->pluginName;
 

--- a/src/controllers/ComponentController.php
+++ b/src/controllers/ComponentController.php
@@ -182,7 +182,7 @@ class ComponentController implements ComponentCtrlInterface
             if ($key === $search) {
                 return $subComponents;
             }
-            if (in_array($key, $this->componentType)) {
+            if (in_array($key, $this->componentType) && !empty($subComponents)) {
                 if ($component = $this->searchComponentByKey($search, $subComponents)) {
                     return $component;
                 }


### PR DESCRIPTION
Fix server returning a 500 error with PHP crashing on ajax call.

When empty component configuration exist prior to check for a panel. The ajax
call $this->componentCtrl->searchComponentByKey($_REQUEST['atkwp']); would
generate a php error. 
