### PR TITLE
MetaBoxComponent::savePost, check for $_POST and key

### DIFF
--- a/src/components/MetaBoxComponent.php
+++ b/src/components/MetaBoxComponent.php
@@ -82,7 +82,9 @@ class MetaBoxComponent extends Component
     {
         if ($this->fieldCtrl) {
             foreach ($this->fieldCtrl->getFields() as $key => $field) {
-                $compCtrl->savePostMetaData($postId, $field->short_name, $this->onUpdateMetaFieldRawData($key, $_POST[$field->short_name]));
+                if (isset($_POST) && array_key_exists($field->short_name, $_POST)) {
+                    $compCtrl->savePostMetaData($postId, $field->short_name, $this->onUpdateMetaFieldRawData($key, $_POST[$field->short_name]));
+                }
             }
         }
     }


### PR DESCRIPTION
MetaBoxComponent::savePost is triggered from do_action('save_post_{post_type}'). This trigger is also called from non admin activity and even from a GET request. This fixes the part where a GET request triggers this action. An additional improvement would be to check if the activity came from an admin activity.